### PR TITLE
Added back and esc options to the assistant button menu

### DIFF
--- a/panels/assistant/cc-assistant-panel.c
+++ b/panels/assistant/cc-assistant-panel.c
@@ -22,8 +22,8 @@ enum PredefinedAction {
     TAKE_SCREENSHOT = 4,
     SEND_TAB = 5,
     MANUAL_AUTOROTATE = 6,
-    SEND_BACK = 7,
-    SEND_ESC = 8,
+    SEND_XF86BACK = 7,
+    SEND_ESCAPE = 8
 };
 
 struct _CcAssistantPanel {
@@ -36,8 +36,8 @@ struct _CcAssistantPanel {
   GtkCheckButton    *take_screenshot;
   GtkCheckButton    *send_tab;
   GtkCheckButton    *manual_autorotate;
-  GtkCheckButton    *send_back;
-  GtkCheckButton    *send_esc;
+  GtkCheckButton    *send_xf86back;
+  GtkCheckButton    *send_escape;
   GtkToggleButton   *short_press;
   GtkToggleButton   *long_press;
   GtkToggleButton   *double_press;
@@ -56,8 +56,8 @@ update_action_sensitivity (CcAssistantPanel *self, gboolean sensitive)
   gtk_widget_set_sensitive (GTK_WIDGET (self->take_screenshot), sensitive);
   gtk_widget_set_sensitive (GTK_WIDGET (self->send_tab), sensitive);
   gtk_widget_set_sensitive (GTK_WIDGET (self->manual_autorotate), sensitive);
-  gtk_widget_set_sensitive (GTK_WIDGET (self->send_back), sensitive);
-  gtk_widget_set_sensitive (GTK_WIDGET (self->send_esc), sensitive);
+  gtk_widget_set_sensitive (GTK_WIDGET (self->send_xf86back), sensitive);
+  gtk_widget_set_sensitive (GTK_WIDGET (self->send_escape), sensitive);
 }
 
 static void
@@ -154,8 +154,8 @@ update_action_buttons (CcAssistantPanel *self, enum PredefinedAction action)
   gtk_check_button_set_active (self->take_screenshot, action == TAKE_SCREENSHOT);
   gtk_check_button_set_active (self->send_tab, action == SEND_TAB);
   gtk_check_button_set_active (self->manual_autorotate, action == MANUAL_AUTOROTATE);
-  gtk_check_button_set_active (self->send_back, action == SEND_BACK);
-  gtk_check_button_set_active (self->send_back, action == SEND_ESC);
+  gtk_check_button_set_active (self->send_xf86back, action == SEND_XF86BACK);
+  gtk_check_button_set_active (self->send_escape, action == SEND_ESCAPE);
 }
 
 static void
@@ -181,10 +181,10 @@ on_action_toggled (GtkCheckButton *button, gpointer user_data)
       action = SEND_TAB;
     else if (g_strcmp0 (action_id, "manual_autorotate") == 0)
       action = MANUAL_AUTOROTATE;
-    else if (g_strcmp0 (action_id, "send_back") == 0)
-      action = SEND_BACK;
-    else if (g_strcmp0 (action_id, "send_esc") == 0)
-      action = SEND_ESC;
+    else if (g_strcmp0 (action_id, "send_xf86back") == 0)
+      action = SEND_XF86BACK;
+    else if (g_strcmp0 (action_id, "send_escape") == 0)
+      action = SEND_ESCAPE;
 
     save_predefined_action (self->current_gesture, action);
     g_debug ("Action selected: %s (enum value: %d) for gesture: %d\n", action_id, action, self->current_gesture);
@@ -256,8 +256,8 @@ cc_assistant_panel_class_init (CcAssistantPanelClass *klass)
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, take_screenshot);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_tab);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, manual_autorotate);
-  gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_back);
-  gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_esc);
+  gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_xf86back);
+  gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_escape);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, short_press);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, long_press);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, double_press);
@@ -276,8 +276,8 @@ cc_assistant_panel_init (CcAssistantPanel *self)
   g_signal_connect (self->take_screenshot, "toggled", G_CALLBACK (on_action_toggled), self);
   g_signal_connect (self->send_tab, "toggled", G_CALLBACK (on_action_toggled), self);
   g_signal_connect (self->manual_autorotate, "toggled", G_CALLBACK (on_action_toggled), self);
-  g_signal_connect (self->send_back, "toggled", G_CALLBACK (on_action_toggled), self);
-  g_signal_connect (self->send_esc, "toggled", G_CALLBACK (on_action_toggled), self);
+  g_signal_connect (self->send_xf86back, "toggled", G_CALLBACK (on_action_toggled), self);
+  g_signal_connect (self->send_escape, "toggled", G_CALLBACK (on_action_toggled), self);
 
   g_signal_connect (self->short_press, "toggled", G_CALLBACK (on_gesture_toggled), self);
   g_signal_connect (self->long_press, "toggled", G_CALLBACK (on_gesture_toggled), self);

--- a/panels/assistant/cc-assistant-panel.c
+++ b/panels/assistant/cc-assistant-panel.c
@@ -22,7 +22,8 @@ enum PredefinedAction {
     TAKE_SCREENSHOT = 4,
     SEND_TAB = 5,
     MANUAL_AUTOROTATE = 6,
-    SEND_BACK = 7
+    SEND_BACK = 7,
+    SEND_ESC = 8,
 };
 
 struct _CcAssistantPanel {
@@ -36,6 +37,7 @@ struct _CcAssistantPanel {
   GtkCheckButton    *send_tab;
   GtkCheckButton    *manual_autorotate;
   GtkCheckButton    *send_back;
+  GtkCheckButton    *send_esc;
   GtkToggleButton   *short_press;
   GtkToggleButton   *long_press;
   GtkToggleButton   *double_press;
@@ -55,6 +57,7 @@ update_action_sensitivity (CcAssistantPanel *self, gboolean sensitive)
   gtk_widget_set_sensitive (GTK_WIDGET (self->send_tab), sensitive);
   gtk_widget_set_sensitive (GTK_WIDGET (self->manual_autorotate), sensitive);
   gtk_widget_set_sensitive (GTK_WIDGET (self->send_back), sensitive);
+  gtk_widget_set_sensitive (GTK_WIDGET (self->send_esc), sensitive);
 }
 
 static void
@@ -152,6 +155,7 @@ update_action_buttons (CcAssistantPanel *self, enum PredefinedAction action)
   gtk_check_button_set_active (self->send_tab, action == SEND_TAB);
   gtk_check_button_set_active (self->manual_autorotate, action == MANUAL_AUTOROTATE);
   gtk_check_button_set_active (self->send_back, action == SEND_BACK);
+  gtk_check_button_set_active (self->send_back, action == SEND_ESC);
 }
 
 static void
@@ -179,6 +183,8 @@ on_action_toggled (GtkCheckButton *button, gpointer user_data)
       action = MANUAL_AUTOROTATE;
     else if (g_strcmp0 (action_id, "send_back") == 0)
       action = SEND_BACK;
+    else if (g_strcmp0 (action_id, "send_esc") == 0)
+      action = SEND_ESC;
 
     save_predefined_action (self->current_gesture, action);
     g_debug ("Action selected: %s (enum value: %d) for gesture: %d\n", action_id, action, self->current_gesture);
@@ -251,6 +257,7 @@ cc_assistant_panel_class_init (CcAssistantPanelClass *klass)
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_tab);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, manual_autorotate);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_back);
+  gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_esc);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, short_press);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, long_press);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, double_press);
@@ -270,6 +277,7 @@ cc_assistant_panel_init (CcAssistantPanel *self)
   g_signal_connect (self->send_tab, "toggled", G_CALLBACK (on_action_toggled), self);
   g_signal_connect (self->manual_autorotate, "toggled", G_CALLBACK (on_action_toggled), self);
   g_signal_connect (self->send_back, "toggled", G_CALLBACK (on_action_toggled), self);
+  g_signal_connect (self->send_esc, "toggled", G_CALLBACK (on_action_toggled), self);
 
   g_signal_connect (self->short_press, "toggled", G_CALLBACK (on_gesture_toggled), self);
   g_signal_connect (self->long_press, "toggled", G_CALLBACK (on_gesture_toggled), self);

--- a/panels/assistant/cc-assistant-panel.c
+++ b/panels/assistant/cc-assistant-panel.c
@@ -21,7 +21,8 @@ enum PredefinedAction {
     TAKE_PICTURE = 3,
     TAKE_SCREENSHOT = 4,
     SEND_TAB = 5,
-    MANUAL_AUTOROTATE = 6
+    MANUAL_AUTOROTATE = 6,
+    SEND_BACK = 7
 };
 
 struct _CcAssistantPanel {
@@ -34,6 +35,7 @@ struct _CcAssistantPanel {
   GtkCheckButton    *take_screenshot;
   GtkCheckButton    *send_tab;
   GtkCheckButton    *manual_autorotate;
+  GtkCheckButton    *send_back;
   GtkToggleButton   *short_press;
   GtkToggleButton   *long_press;
   GtkToggleButton   *double_press;
@@ -52,6 +54,7 @@ update_action_sensitivity (CcAssistantPanel *self, gboolean sensitive)
   gtk_widget_set_sensitive (GTK_WIDGET (self->take_screenshot), sensitive);
   gtk_widget_set_sensitive (GTK_WIDGET (self->send_tab), sensitive);
   gtk_widget_set_sensitive (GTK_WIDGET (self->manual_autorotate), sensitive);
+  gtk_widget_set_sensitive (GTK_WIDGET (self->send_back), sensitive);
 }
 
 static void
@@ -148,6 +151,7 @@ update_action_buttons (CcAssistantPanel *self, enum PredefinedAction action)
   gtk_check_button_set_active (self->take_screenshot, action == TAKE_SCREENSHOT);
   gtk_check_button_set_active (self->send_tab, action == SEND_TAB);
   gtk_check_button_set_active (self->manual_autorotate, action == MANUAL_AUTOROTATE);
+  gtk_check_button_set_active (self->send_back, action == SEND_BACK);
 }
 
 static void
@@ -173,6 +177,8 @@ on_action_toggled (GtkCheckButton *button, gpointer user_data)
       action = SEND_TAB;
     else if (g_strcmp0 (action_id, "manual_autorotate") == 0)
       action = MANUAL_AUTOROTATE;
+    else if (g_strcmp0 (action_id, "send_back") == 0)
+      action = SEND_BACK;
 
     save_predefined_action (self->current_gesture, action);
     g_debug ("Action selected: %s (enum value: %d) for gesture: %d\n", action_id, action, self->current_gesture);
@@ -244,6 +250,7 @@ cc_assistant_panel_class_init (CcAssistantPanelClass *klass)
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, take_screenshot);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_tab);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, manual_autorotate);
+  gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, send_back);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, short_press);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, long_press);
   gtk_widget_class_bind_template_child (widget_class, CcAssistantPanel, double_press);
@@ -262,6 +269,7 @@ cc_assistant_panel_init (CcAssistantPanel *self)
   g_signal_connect (self->take_screenshot, "toggled", G_CALLBACK (on_action_toggled), self);
   g_signal_connect (self->send_tab, "toggled", G_CALLBACK (on_action_toggled), self);
   g_signal_connect (self->manual_autorotate, "toggled", G_CALLBACK (on_action_toggled), self);
+  g_signal_connect (self->send_back, "toggled", G_CALLBACK (on_action_toggled), self);
 
   g_signal_connect (self->short_press, "toggled", G_CALLBACK (on_gesture_toggled), self);
   g_signal_connect (self->long_press, "toggled", G_CALLBACK (on_gesture_toggled), self);

--- a/panels/assistant/cc-assistant-panel.ui
+++ b/panels/assistant/cc-assistant-panel.ui
@@ -163,6 +163,19 @@
                               </object>
                             </child>
 
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Send back key</property>
+                                <property name="use-underline">True</property>
+                                <child type="prefix">
+                                  <object class="GtkCheckButton" id="send_back">
+                                    <property name="valign">center</property>
+                                    <property name="group">no_action</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+
                           </object>
                         </child>
 

--- a/panels/assistant/cc-assistant-panel.ui
+++ b/panels/assistant/cc-assistant-panel.ui
@@ -139,7 +139,7 @@
 
                             <child>
                               <object class="AdwActionRow">
-                                <property name="title" translatable="yes">Send tab key</property>
+                                <property name="title" translatable="yes">Send Tab key</property>
                                 <property name="use-underline">True</property>
                                 <child type="prefix">
                                   <object class="GtkCheckButton" id="send_tab">
@@ -165,10 +165,10 @@
 
                             <child>
                               <object class="AdwActionRow">
-                                <property name="title" translatable="yes">Send back key</property>
+                                <property name="title" translatable="yes">Send Back key</property>
                                 <property name="use-underline">True</property>
                                 <child type="prefix">
-                                  <object class="GtkCheckButton" id="send_back">
+                                  <object class="GtkCheckButton" id="send_xf86back">
                                     <property name="valign">center</property>
                                     <property name="group">no_action</property>
                                   </object>
@@ -178,10 +178,10 @@
 
                             <child>
                               <object class="AdwActionRow">
-                                <property name="title" translatable="yes">Send escape key</property>
+                                <property name="title" translatable="yes">Send Escape key</property>
                                 <property name="use-underline">True</property>
                                 <child type="prefix">
-                                  <object class="GtkCheckButton" id="send_esc">
+                                  <object class="GtkCheckButton" id="send_escape">
                                     <property name="valign">center</property>
                                     <property name="group">no_action</property>
                                   </object>

--- a/panels/assistant/cc-assistant-panel.ui
+++ b/panels/assistant/cc-assistant-panel.ui
@@ -176,6 +176,19 @@
                               </object>
                             </child>
 
+                            <child>
+                              <object class="AdwActionRow">
+                                <property name="title" translatable="yes">Send escape key</property>
+                                <property name="use-underline">True</property>
+                                <child type="prefix">
+                                  <object class="GtkCheckButton" id="send_esc">
+                                    <property name="valign">center</property>
+                                    <property name="group">no_action</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+
                           </object>
                         </child>
 


### PR DESCRIPTION
Added possibility to choose back and esc buttons in the assistant button menu.
Related to [assistant-button/pull/1](https://github.com/FuriLabs/assistant-button/pull/1)